### PR TITLE
Object::getAutoSize fix

### DIFF
--- a/src/Components/Object.php
+++ b/src/Components/Object.php
@@ -259,7 +259,7 @@ abstract class Object
      */
     public function getAutoSize()
     {
-        return $this->get('color');
+        return $this->get('autosize');
     }
 
     /**


### PR DESCRIPTION
`Object::getAutoSize` was returning BackgroundColor.