### PR TITLE
Fixed stream block after getProperty of a Object

### DIFF
--- a/src/Ipc/Receiver.php
+++ b/src/Ipc/Receiver.php
@@ -327,7 +327,7 @@ class Receiver
             usleep(1);
         }
 
-        $stdout->resume();
+        //$stdout->resume();
 
         $result = $this->waitingMessageResult;
         $this->waitingMessageResult = null;


### PR DESCRIPTION
This happens when you try to get value of a InputText, it worked. After that, stream is stopped and cannot get any message.