### PR TITLE
Handling  on("exit"), and fixing froxen console

### DIFF
--- a/examples/06-ping/example.php
+++ b/examples/06-ping/example.php
@@ -29,20 +29,21 @@ $application->on('start', function() use ($application) {
     // Disable application verbose, to see the speed messages
     $application->setVerboseLevel(0);
 
-    while (true) {
-        $latency = $application->ping();
+    $application->getLoop()->addPeriodicTimer(
+        0.000001,
+        function() use ($application, & $currentSecond, & $messagesPerSecond) {
+            $latency = $application->ping();
 
-        if (time() != $currentSecond) {
-            Output::out('Speed: ' . $messagesPerSecond . ' messages/sec', 'red');
+            if (time() != $currentSecond) {
+                Output::out('Speed: ' . $messagesPerSecond . ' messages/sec', 'red');
 
-            $messagesPerSecond = 0;
-            $currentSecond = time();
+                $messagesPerSecond = 0;
+                $currentSecond = time();
+            }
+
+            $messagesPerSecond++;
         }
-
-        $messagesPerSecond++;
-
-        usleep(1);
-    }
+    );
 });
 
 $application->run();

--- a/src/Application.php
+++ b/src/Application.php
@@ -286,6 +286,8 @@ class Application
         $this->process = $process = new Process($processName, $processPath);
 
         $this->process->on('exit', function () use ($application) {
+            $this->fire('exit');
+            $this->running = false;
             $application->loop->stop();
         });
 
@@ -443,5 +445,17 @@ class Application
         if ($this->getObject($objectId)) {
             unset($this->objects[$objectId]);
         }
+    }
+
+    /**
+     * Gets the Defines if the application is running.
+     *
+     * @return bool $running
+     */
+    public function isRunning()
+    {
+        $this->running = ! $this->process->isRunning() ? false : $this->running;
+
+        return $this->running;
     }
 }

--- a/src/Ipc/Receiver.php
+++ b/src/Ipc/Receiver.php
@@ -314,7 +314,7 @@ class Receiver
      *
      * @return mixed The result
      */
-    public function waitMessage(Stream $stdout, MessageInterface $message)
+    public function waitMessage(Stream $stdout, MessageInterface $message, Application $application)
     {
         $buffer = [];
 
@@ -322,7 +322,7 @@ class Receiver
         $this->isWaitingMessage = true;
 
         // Read the stdin until we get the message replied
-        while ($this->isWaitingMessage) {
+        while ($this->isWaitingMessage && $application->isRunning()) {
             $this->tick();
             usleep(1);
         }

--- a/src/Ipc/Sender.php
+++ b/src/Ipc/Sender.php
@@ -162,7 +162,8 @@ class Sender
 
         return $this->receiver->waitMessage(
             $this->application->process->stdout,
-            $message
+            $message,
+            $this->application
         );
     }
 


### PR DESCRIPTION
This commit fix the frozen console when you ran `php example/06-ping/example.php` and close the window.

And also, when the application will be stopped is fired an event "exit" that you can handle using: `\Gui\Application::on('exit', closure)`