### PR TITLE
Making canvas setSize() much more flexible

### DIFF
--- a/src/Components/Canvas.php
+++ b/src/Components/Canvas.php
@@ -70,6 +70,36 @@ class Canvas extends VisualObject
      */
     public function setSize($width, $height)
     {
+        if (is_string($width)) {
+            $parent = 0;
+
+            if (strpos($width, "vw") !== false) {
+                $width = floatval(str_replace("vw", "", $width));
+                $parent = $this->getWidth();
+            }
+            else if (strpos($width, "vh") !== false) {
+                $width = floatval(str_replace("vh", "", $width));
+                $parent = $this->getheight();
+            }
+
+            $width = $parent * ($width / 100);
+        }
+
+        if (is_string($height)) {
+            $parent = 0;
+
+            if (strpos($height, "vw") !== false) {
+                $height = floatval(str_replace("vw", "", $height));
+                $parent = $this->getWidth();
+            }
+            else if (strpos($height, "vh") !== false) {
+                $height = floatval(str_replace("vh", "", $height));
+                $parent = $this->getheight();
+            }
+
+            $height = $parent * ($height / 100);
+        }
+
         $this->call(
             'picture.bitmap.setSize',
             [

--- a/src/Components/Canvas.php
+++ b/src/Components/Canvas.php
@@ -63,8 +63,8 @@ class Canvas extends VisualObject
     /**
      * Sets the canvas size
      *
-     * @param int $width
-     * @param int $height
+     * @param int|string $width
+     * @param int|string $height
      *
      * @return self
      */


### PR DESCRIPTION
I made the Canvas->`setSize()` function accept a string with **vh** or **vw** units as well as the default integers. This allows canvas elements to be able to set to a percent of the viewport.

This enhances the capability of the canvas element. Users can now use it much more flexibly.

For example:

```
$application->getLoop()->addTimer(0.01, function() use ($canvas) {
    $canvas->setSize("10vw", "20vh");
});
```

Acceptable parameters for `setSize()` are now either integers or strings containing the `vh` or `vw` units.

You don't have to use viewport width (vw) to set the width. You can use either unit for either width or height! For example, you can set the canvas width to be 50% of the viewport height with:

`setSize("50vh", 100);`

So if the viewport height is 600 pixels this will set the width of the canvas to 300 pixels.