### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev" : {
         "phing/phing": "2.*",
-        "phpunit/phpunit": "4.5.*",
+        "phpunit/phpunit": "^4.8.35",
         "squizlabs/php_codesniffer": "2.0.*@dev",
         "evert/phpdoc-md" : "~0.2.0",
         "phpdocumentor/phpdocumentor": "^2.8"

--- a/test/ApplicationTest.php
+++ b/test/ApplicationTest.php
@@ -4,8 +4,9 @@ namespace Test;
 
 use Gui\Application;
 use Gui\Components\Window;
+use PHPUnit\Framework\TestCase;
 
-class ApplicationTest extends \PHPUnit_Framework_TestCase
+class ApplicationTest extends TestCase
 {
     public function testGetNextObjectId()
     {

--- a/test/ColorTest.php
+++ b/test/ColorTest.php
@@ -3,8 +3,9 @@
 namespace Test;
 
 use Gui\Color;
+use PHPUnit\Framework\TestCase;
 
-class ColorTest extends \PHPUnit_Framework_TestCase
+class ColorTest extends TestCase
 {
     public function testColorToLazarus()
     {

--- a/test/Components/ObjectTest.php
+++ b/test/Components/ObjectTest.php
@@ -4,8 +4,9 @@ namespace Test\Components;
 
 use Gui\Application;
 use Gui\Components\Window;
+use PHPUnit\Framework\TestCase;
 
-class ObjectTest extends \PHPUnit_Framework_TestCase
+class ObjectTest extends TestCase
 {
     public function testMagicCall()
     {

--- a/test/Components/RadioTest.php
+++ b/test/Components/RadioTest.php
@@ -5,8 +5,9 @@ namespace Test\Components;
 use Gui\Application;
 use Gui\Components\Option;
 use Gui\Components\Radio;
+use PHPUnit\Framework\TestCase;
 
-class RadioTest extends \PHPUnit_Framework_TestCase
+class RadioTest extends TestCase
 {
 
     public function testSetOptions()

--- a/test/Ipc/CommandMessageTest.php
+++ b/test/Ipc/CommandMessageTest.php
@@ -3,8 +3,9 @@
 namespace Test\Ipc;
 
 use Gui\Ipc\CommandMessage;
+use PHPUnit\Framework\TestCase;
 
-class CommandMessageTest extends \PHPUnit_Framework_TestCase
+class CommandMessageTest extends TestCase
 {
     public function testConstructor()
     {

--- a/test/Ipc/EventMessageTest.php
+++ b/test/Ipc/EventMessageTest.php
@@ -3,8 +3,9 @@
 namespace Test\Ipc;
 
 use Gui\Ipc\CommandMessage;
+use PHPUnit\Framework\TestCase;
 
-class EventMessageTest extends \PHPUnit_Framework_TestCase
+class EventMessageTest extends TestCase
 {
     public function testConstructor()
     {

--- a/test/Ipc/ReceiverTest.php
+++ b/test/Ipc/ReceiverTest.php
@@ -5,9 +5,10 @@ namespace Test\Ipc;
 use Gui\Application;
 use Gui\Exception\ComponentException;
 use Gui\Ipc\Receiver;
+use PHPUnit\Framework\TestCase;
 use Test\Util;
 
-class ReceiverTest extends \PHPUnit_Framework_TestCase
+class ReceiverTest extends TestCase
 {
     public function testConstructor()
     {

--- a/test/Ipc/SenderTest.php
+++ b/test/Ipc/SenderTest.php
@@ -5,8 +5,9 @@ namespace Test\Ipc;
 use Gui\Application;
 use Gui\Ipc\Receiver;
 use Gui\Ipc\Sender;
+use PHPUnit\Framework\TestCase;
 
-class SenderTest extends \PHPUnit_Framework_TestCase
+class SenderTest extends TestCase
 {
     public function testConstructor()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.