### PR TITLE
Trim JSON before splitting

### DIFF
--- a/src/Ipc/Receiver.php
+++ b/src/Ipc/Receiver.php
@@ -152,6 +152,7 @@ class Receiver
      */
     protected function jsonSplit($json, &$carry = [])
     {
+        $json = trim($json);
         @json_decode($json);
         if (json_last_error() === JSON_ERROR_NONE) {
             $carry[] = $json;


### PR DESCRIPTION
Splitting JSON must be trimmed first, otherwise it will not be splitted properly.